### PR TITLE
Updates the dependencies in part5-9 to 0.19

### DIFF
--- a/intro/part5/elm.json
+++ b/intro/part5/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/json-decode-pipeline": "1.0.0",
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -16,7 +16,7 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-http-builder": "6.0.0",
-            "rtfeldman/elm-iso8601": "1.0.1"
+            "rtfeldman/elm-iso8601-date-strings": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.0.0",

--- a/intro/part6/elm.json
+++ b/intro/part6/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/json-decode-pipeline": "1.0.0",
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -16,7 +16,7 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-http-builder": "6.0.0",
-            "rtfeldman/elm-iso8601": "1.0.1"
+            "rtfeldman/elm-iso8601-date-strings": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.0.0",

--- a/intro/part7/elm.json
+++ b/intro/part7/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/json-decode-pipeline": "1.0.0",
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -16,7 +16,7 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-http-builder": "6.0.0",
-            "rtfeldman/elm-iso8601": "1.0.1"
+            "rtfeldman/elm-iso8601-date-strings": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.0.0",

--- a/intro/part8/elm.json
+++ b/intro/part8/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/json-decode-pipeline": "1.0.0",
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -16,7 +16,7 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-http-builder": "6.0.0",
-            "rtfeldman/elm-iso8601": "1.0.1"
+            "rtfeldman/elm-iso8601-date-strings": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.0.0",

--- a/intro/part9/elm.json
+++ b/intro/part9/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "NoRedInk/json-decode-pipeline": "1.0.0",
+            "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -16,7 +16,7 @@
             "elm/url": "1.0.0",
             "elm-explorations/markdown": "1.0.0",
             "lukewestby/elm-http-builder": "6.0.0",
-            "rtfeldman/elm-iso8601": "1.0.1"
+            "rtfeldman/elm-iso8601-date-strings": "1.0.0"
         },
         "indirect": {
             "elm/parser": "1.0.0",


### PR DESCRIPTION
In attempting the `elm make` call in part received this error:

-- CORRUPT CACHE ---------------------------------------------------------------

I ran into an unknown package while exploring dependencies:

    NoRedInk/json-decode-pipeline

This suggests that your /Users/{UserName}/.elm directory has been corrupted.
Maybe some program is messing with it? It is just cached files, so you can
delete it and see if that fixes the issue.

The names of two of the modules appear to have changed for 0.19. This is
currently updated in the solutions branch but not the master branch.

Feel free to delete this if it doesn't fit into your workflow once the issue is resolved.
It seemed nicest to open this as PR in case anyone else ran into the same
issue and is looking for answers.