### PR TITLE
Fix elm-test install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Getting Started
 > **Note:** Make sure not to run this command with `sudo`! If it gives you an `EACCESS` error, apply [**this fix**](https://docs.npmjs.com/getting-started/fixing-npm-permissions#option-two-change-npms-default-directory) and then re-run the command (still without `sudo`).
 
 ```shell
-npm install -g elm elm-test@elm-0.19.0 elm-format
+npm install -g elm elm-test@elm0.19.0 elm-format
 ```
 
 5. Clone this repository


### PR DESCRIPTION
Npm tagged release does not use the dash that was present before `elm-0.19.0`, removing it solves the problem `elm0.19.0`.

Solves #4.