### PR TITLE
0.19 Solution Update

### DIFF
--- a/intro/part2/src/Main.elm
+++ b/intro/part2/src/Main.elm
@@ -7,7 +7,7 @@ import Html.Attributes exposing (..)
 viewTags tags =
     let
         renderedTags =
-            List.map viewTag tags
+            (\x -> List.map viewTag tags)
     in
     div [ class "tag-list" ] renderedTags
 


### PR DESCRIPTION
List.map no longer allows more than 2 arguments outside of an anonymous function.