### PR TITLE
Fix the HINT for List.filter

### DIFF
--- a/intro/part6/src/Page/Article/Editor.elm
+++ b/intro/part6/src/Page/Article/Editor.elm
@@ -568,7 +568,7 @@ toTagList tagString =
 
        💡 HINT: Here's how to remove all the "foo" strings from a list of strings:
 
-       List.filter (\str -> str == "foo") listOfStrings
+       List.filter (\str -> not (str == "foo")) listOfStrings
     -}
     String.split " " tagString
         |> List.map String.trim


### PR DESCRIPTION
List.filter keeps the elements that satisfy the test and does not remove them as the original HINT suggests.