### PR TITLE
Update package.json

### DIFF
--- a/intro/server/package.json
+++ b/intro/server/package.json
@@ -26,7 +26,7 @@
     "moleculer": "^0.11.0",
     "moleculer-db": "0.7.0",
     "moleculer-db-adapter-mongo": "0.1.6",
-    "moleculer-web": "0.6.0-beta7",
+    "moleculer-web": "^0.8.5",
     "nats": "0.7.24",
     "slug": "0.9.1"
   },


### PR DESCRIPTION
 in the repository, you've got a beta version of moleculer in the package.json but that crashes. With this error "cannot enable cancellation after promises are in use" - this is due to Node removing the ability to cancel promises a while back.

I updated the moleculer-web version which seems to fix that. I haven't tested it in all scenarios.

Also, I noted that you are recommending using Node 7 or higher. However, I would recommend you make it Node 8 - the odd versions are not LTS, which seems a little dicey to me IMHO.