### PR TITLE
Include "elm/virtual-dom" in indirect dependencies

### DIFF
--- a/intro/part3/elm.json
+++ b/intro/part3/elm.json
@@ -12,7 +12,8 @@
         "indirect": {
             "elm/json": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0"
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.0"
         }
     },
     "test-dependencies": {


### PR DESCRIPTION
The project build kept failing and the Elm compiler kept telling me the file was "edited by hand" even though it was a fresh clone. Then I noticed part4 has the same elm.json file except for "elm/virtual-dom". Upon including that the build works!